### PR TITLE
fix: 修正书写不规范时的异常

### DIFF
--- a/lib/clientRootMixin.js
+++ b/lib/clientRootMixin.js
@@ -61,7 +61,7 @@ var getHtmlTpl = function getHtmlTpl(html) {
 };
 
 var getVueJsTpl = function getVueJsTpl(js) {
-  var jsContent = js.replace(/export default\s*?\{\n/, '').replace(/\n}$/, '').trim();
+  var jsContent = js.replace(/export\s+default\s*?\{\n*/, '').replace(/\n*\}\s*$/, '').trim();
   return "new Vue({\n  el: '#app',\n  ".concat(jsContent, "\n})");
 };
 
@@ -91,7 +91,7 @@ var $ = function $(parent, node, returnArray) {
 };
 
 var getVueScript = function getVueScript(js, html) {
-  var scripts = js.split('export default');
+  var scripts = js.split(/export\s+default/);
   var scriptStrOrg = "(function() {".concat(scripts[0], " ; return ").concat(scripts[1], "})()");
   var scriptStr = window.Babel ? window.Babel.transform(scriptStrOrg, {
     presets: ['es2015']

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,8 @@ ${html}
 
 const getVueJsTpl = js => {
   const jsContent = js
-    .replace(/export default\s*?\{\n/, '')
-    .replace(/\n}$/, '')
+    .replace(/export\s+default\s*?\{\n*/, '')
+    .replace(/\n*\}\s*$/, '')
     .trim()
   return `new Vue({
   el: '#app',
@@ -43,7 +43,7 @@ export const $ = (parent, node, returnArray) => {
 }
 
 const getVueScript = (js, html) => {
-  const scripts = js.split('export default')
+  const scripts = js.split(/export\s+default/)
   const scriptStrOrg = `(function() {${scripts[0]} ; return ${scripts[1]}})()`
   const scriptStr = window.Babel
     ? window.Babel.transform(scriptStrOrg, { presets: ['es2015'] }).code


### PR DESCRIPTION
1. export 和 default中间多余空白符存在时，编译不通过
2. script 结尾不匹配时，结尾的 '}' 无法被消除